### PR TITLE
Development environment setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ _site/atom.xml
 _site/index.html
 /.jekyll-cache
 .DS_Store
+vendor/
+.bundle/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a **Jekyll + Tailwind CSS static site** (Amalgam Capital corporate website). No backend, database, or Docker required.
+
+### Prerequisites (installed by update script)
+- **Ruby** (≥2.7) + Bundler — gems installed to `vendor/bundle` via `bundle install`
+- **Node.js** + npm — Tailwind CSS toolchain via `npm install`
+
+### Running the site
+1. Build Tailwind CSS: `npm run build-css-prod` (one-shot) or `npm run build-css` (watch mode)
+2. Serve locally: `bundle exec jekyll serve --host 0.0.0.0 --port 4000`
+3. Open `http://localhost:4000`
+
+### Key caveats
+- Bundler must use a local path (`vendor/bundle`) since the system gem directory is not writable. The update script sets this via `bundle config set --local path 'vendor/bundle'`.
+- The `_config.yml` uses `plugins_dir` instead of `plugins` for some plugin declarations — this is a known Jekyll quirk in this repo but doesn't affect the build.
+- There is no formal linting (ESLint/Rubocop) or automated test suite configured. The README mentions `htmlproofer` but it is not in the Gemfile.
+- The build/test workflow is: `npm run build-css-prod && bundle exec jekyll build`. Success = zero exit code.
+- For full dev reference, see `readme.md` in the repo root.


### PR DESCRIPTION
Add `vendor/` and `.bundle/` to `.gitignore` and create `AGENTS.md` to properly manage bundled gems and provide cloud development instructions.

---
<p><a href="https://cursor.com/agents/bc-4ad5b5b6-f425-468f-9e11-02c8136eeb00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4ad5b5b6-f425-468f-9e11-02c8136eeb00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

