### PR TITLE
Fix RegExp to target HTML tag name only

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -73,9 +73,9 @@ function CopyToClipboard(element) {
         .cssText;
       //chang Element tag from block level elements to inline level elements (span)
       descendents[i].outerHTML = descendents[i].outerHTML.replace(
-        new RegExp(tagname, "ig"),
-        "span"
-      ); //todo: need to change RegExp to tag name only not inner text
+        new RegExp("(<\\/?)" + tagname + "(\\s|\\/?>)", "ig"),
+        "$1span$2"
+      );
       //add all Element style include default style to new tag
       descendents[i].style.cssText = defultcss;
     }


### PR DESCRIPTION
The current RegExp in `_layouts/page.html` replaces all occurrences of the tag name in the element's outerHTML, which unintentionally modifies the inner text and attributes. I've updated the RegExp to specifically match HTML tag names (e.g., `<tag>`, `</tag>`, or `<tag ...>`) and preserve the surrounding characters using capture groups. Verified the fix with various test cases including attributes and inner content.

---
*PR created automatically by Jules for task [2460834237045050821](https://jules.google.com/task/2460834237045050821) started by @rachitshukla*