### PR TITLE
🔒 [security fix description] Add rel="noopener noreferrer" to vulnerable anchor tags

### DIFF
--- a/_layouts/contactpage.html
+++ b/_layouts/contactpage.html
@@ -70,7 +70,7 @@ window.addEventListener('resize', initVanta);
 					{% if page.linkedin %}
 					<div class="flex items-center justify-center space-x-3">
 						<i class="fa-duotone fa-light fa-linkedin text-brand-coral-600 dark:text-brand-gold text-xl"></i>
-						<a href="{{ page.linkedin }}" target="_blank" class="text-lg text-brand-coral-700 dark:text-brand-gold-200 hover:text-brand-coral-800 dark:hover:text-brand-gold transition-colors">
+						<a href="{{ page.linkedin }}" target="_blank" rel="noopener noreferrer" class="text-lg text-brand-coral-700 dark:text-brand-gold-200 hover:text-brand-coral-800 dark:hover:text-brand-gold transition-colors">
 							LinkedIn Profile
 						</a>
 					</div>

--- a/_layouts/portfolio.html
+++ b/_layouts/portfolio.html
@@ -58,7 +58,7 @@ layout: default
 			</div>
 
 			{% if platform.website %}
-			<a class="inline-block p-4 bg-brand-coral/50 hover:bg-brand-coral dark:hover:bg-brand-dark-900/50 dark:hover:text-brand-coral dark:bg-brand-gold dark:text-brand-dark rounded-lg font-medium transition-colors" href="{{platform.website}}" target="_blank">Learn About {{platform.name}} <i class="fa-duotone fa-light fa-arrow-right ml-2"></i></a>
+			<a class="inline-block p-4 bg-brand-coral/50 hover:bg-brand-coral dark:hover:bg-brand-dark-900/50 dark:hover:text-brand-coral dark:bg-brand-gold dark:text-brand-dark rounded-lg font-medium transition-colors" href="{{platform.website}}" target="_blank" rel="noopener noreferrer">Learn About {{platform.name}} <i class="fa-duotone fa-light fa-arrow-right ml-2"></i></a>
 			{% endif %}
 		</div>
 		{% endfor %}

--- a/email.md
+++ b/email.md
@@ -16,7 +16,7 @@ noindex: true
          <table cellspacing="0" cellpadding="0" border="0">
             <tr>
                <td valign="top" width="80" style="padding:0 8px 0 0;vertical-align: top;">
-               	<a href="http://amalgam.capital" target="_blank"><img alt="Amalgam Capital" width="80" style="width:80px;moz-border-radius:100%;khtml-border-radius:100%;o-border-radius:10%;webkit-border-radius:100%;ms-border-radius:100%;border-radius:100%;" src="https://amalgamcapital.com/images/logo-circle.png" /></a>
+		<a href="http://amalgam.capital" target="_blank" rel="noopener noreferrer"><img alt="Amalgam Capital" width="80" style="width:80px;moz-border-radius:100%;khtml-border-radius:100%;o-border-radius:10%;webkit-border-radius:100%;ms-border-radius:100%;border-radius:100%;" src="https://amalgamcapital.com/images/logo-circle.png" /></a>
                </td>
                <td style="font-size:1em;padding:0 15px 0 8px;vertical-align: top;" valign="top">
                   <table cellspacing="0" cellpadding="0" border="0" style="line-height: 1.1;">
@@ -35,7 +35,7 @@ noindex: true
                         <td style="padding: 0;"><a style="font: 0.75em Verdana, Geneva, sans-serif;color:#F16545; text-decoration: none;" href="tel:(XXX) XXX-XXXX">(XXX) XXX-XXXX</a></td>
                      </tr>
                      <tr style="padding: 0;">
-                        <td style="padding: 0;"><a style="font: 0.75em Verdana, Geneva, sans-serif;color:#F16545; text-decoration: none;" href="http://amalgam.capital" target="_blank">amalgam.capital</a></td>
+                        <td style="padding: 0;"><a style="font: 0.75em Verdana, Geneva, sans-serif;color:#F16545; text-decoration: none;" href="http://amalgam.capital" target="_blank" rel="noopener noreferrer">amalgam.capital</a></td>
                      </tr>
                   </table>
                </td>


### PR DESCRIPTION
🎯 **What:** Fixed a security vulnerability where anchor tags with `target="_blank"` were missing the `rel="noopener noreferrer"` attribute.

⚠️ **Risk:** The use of `target="_blank"` without `rel="noopener noreferrer"` allows the newly opened page to access the original page's `window.opener` object, potentially leading to phishing attacks (reverse tabnabbing) and unnecessary referrer leakage.

🛡️ **Solution:** Added the `rel="noopener noreferrer"` attribute to all identified anchor tags using `target="_blank"` in `_layouts/contactpage.html`, `email.md`, and `_layouts/portfolio.html`. A repository-wide scan confirmed that all such instances are now secured.

Verified the changes via `read_file` and `grep`. Although the project build (Jekyll and Tailwind CSS) encountered environment timeouts during dependency installation, the trivial nature of the HTML-only fix and manual verification ensure its correctness and safety.

---
*PR created automatically by Jules for task [4492990213205481649](https://jules.google.com/task/4492990213205481649) started by @rachitshukla*